### PR TITLE
Add frontend UI and API for calendar planner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,56 @@
+# CalendarV2 Planner
+
+Проект предоставляет планировщик с веб-интерфейсом и API вокруг оптимизатора из `src/scheduler`.
+
+## Структура
+
+- `src/api/` — FastAPI-приложение, которое управляет событиями, гибкими окнами и взаимодействием с оптимизатором.
+- `frontend/` — React + Vite интерфейс с формами добавления задач, настройками гибкости и визуализацией свободных слотов.
+- `frontend/tests/` — e2e тесты на Playwright для ключевых пользовательских сценариев.
+
+## Запуск бэкенда
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+uvicorn src.api.main:app --reload
+```
+
+API поднимается на `http://localhost:8000`. Основные эндпоинты:
+
+- `GET /api/schedule` — текущее расписание, свободные окна и настройки дня.
+- `POST /api/events` — добавление фиксированных и гибких событий.
+- `PUT /api/events/{event_id}` — обновление событий.
+- `DELETE /api/events/{event_id}` — удаление события.
+- `POST /api/events/{event_id}/complete` — завершение события с пересчётом расписания.
+- `PUT /api/settings` — изменение границ рабочего дня.
+- `POST /api/proposals` — подбор рекомендуемых временных интервалов.
+
+## Запуск фронтенда
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+Vite проксирует запросы `/api/*` на `http://localhost:8000`, поэтому UI сразу общается с запущенным бэкендом. Готовая сборка собирается командой `npm run build`, предпросмотр — `npm run preview`.
+
+## Тесты
+
+End-to-end сценарии находятся в `frontend/tests/e2e.spec.ts` и моделируют ключевой поток создания гибкого события. Запуск тестов:
+
+```bash
+cd frontend
+npm install
+npx playwright install --with-deps
+npm test
+```
+
+Тесты используют роутинг Playwright, чтобы изолированно проверить UI без реального бэкенда.
+
+## Дополнительно
+
+- CORS не требуется — прокси на уровне Vite маршрутизирует запросы во время разработки.
+- В рабочей среде фронтенд может обращаться к API напрямую по `/api`, если настроить reverse proxy (например, Nginx) или включить CORS в FastAPI.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="ru">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Calendar Planner</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "calendarv2-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "playwright test"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.43.0",
+    "@types/react": "^18.2.37",
+    "@types/react-dom": "^18.2.15",
+    "@vitejs/plugin-react": "^4.2.0",
+    "typescript": "^5.3.3",
+    "vite": "^5.0.0"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,487 @@
+import { ChangeEvent, FormEvent, useEffect, useMemo, useState } from "react";
+
+interface ApiEvent {
+  event_id: string;
+  type: "fixed" | "flexible";
+  duration_minutes: number;
+  importance: number;
+  details: Record<string, unknown>;
+}
+
+interface ApiBlock {
+  start: string;
+  end: string;
+  event_id: string;
+  type: "fixed" | "flexible";
+  chunk_index?: number | null;
+  chunk_count?: number | null;
+}
+
+interface ApiSchedule {
+  day_start: string;
+  day_end: string;
+  events: ApiEvent[];
+  blocks: ApiBlock[];
+  free_windows: { start: string; end: string }[];
+}
+
+interface EventFormState {
+  eventId: string;
+  type: "fixed" | "flexible";
+  durationMinutes: number;
+  importance: number;
+  start: string;
+  earliestStart: string;
+  latestFinish: string;
+  canSplit: boolean;
+  minChunkMinutes: number;
+}
+
+interface SettingsFormState {
+  dayStart: string;
+  dayEnd: string;
+}
+
+interface ProposalPreview {
+  blocks: ApiBlock[];
+  free_windows: { start: string; end: string }[];
+}
+
+const defaultEventForm: EventFormState = {
+  eventId: "",
+  type: "flexible",
+  durationMinutes: 60,
+  importance: 1,
+  start: "",
+  earliestStart: "",
+  latestFinish: "",
+  canSplit: false,
+  minChunkMinutes: 30
+};
+
+function formatDateTime(value: string): string {
+  if (!value) return "—";
+  const date = new Date(value);
+  return new Intl.DateTimeFormat("ru-RU", {
+    dateStyle: "short",
+    timeStyle: "short"
+  }).format(date);
+}
+
+function toIso(value: string): string | undefined {
+  if (!value) return undefined;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return undefined;
+  return date.toISOString();
+}
+
+function toLocalInput(value: string | undefined): string {
+  if (!value) return "";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  const tzOffset = date.getTimezoneOffset();
+  const localDate = new Date(date.getTime() - tzOffset * 60000);
+  return localDate.toISOString().slice(0, 16);
+}
+
+function buildEventPayload(form: EventFormState, includeId = true) {
+  const base = {
+    type: form.type,
+    duration_minutes: form.durationMinutes,
+    importance: form.importance,
+    can_split: form.type === "flexible" ? form.canSplit : false,
+    min_chunk_minutes: form.minChunkMinutes
+  } as Record<string, unknown>;
+
+  if (form.type === "fixed") {
+    base.start = toIso(form.start);
+  } else {
+    base.earliest_start = toIso(form.earliestStart);
+    base.latest_finish = toIso(form.latestFinish);
+  }
+
+  if (includeId) {
+    base.event_id = form.eventId;
+  }
+  return base;
+}
+
+const App = () => {
+  const [schedule, setSchedule] = useState<ApiSchedule | null>(null);
+  const [form, setForm] = useState<EventFormState>(defaultEventForm);
+  const [settingsForm, setSettingsForm] = useState<SettingsFormState>({
+    dayStart: "",
+    dayEnd: ""
+  });
+  const [proposal, setProposal] = useState<ProposalPreview | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  const fetchSchedule = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch("/api/schedule");
+      if (!response.ok) {
+        throw new Error("Не удалось загрузить расписание");
+      }
+      const data: ApiSchedule = await response.json();
+      setSchedule(data);
+      setSettingsForm({
+        dayStart: toLocalInput(data.day_start),
+        dayEnd: toLocalInput(data.day_end)
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchSchedule();
+  }, []);
+
+  const handleFormChange = (key: keyof EventFormState) =>
+    (event: ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+      const value =
+        event.target.type === "checkbox"
+          ? (event.target as HTMLInputElement).checked
+          : event.target.value;
+      setForm((prev) => ({
+        ...prev,
+        [key]:
+          key === "durationMinutes" ||
+          key === "importance" ||
+          key === "minChunkMinutes"
+            ? Number(value)
+            : value
+      }));
+    };
+
+  const handleCreate = async (event: FormEvent) => {
+    event.preventDefault();
+    setError(null);
+    setSuccess(null);
+
+    if (!form.eventId.trim()) {
+      setError("Введите идентификатор события");
+      return;
+    }
+
+    try {
+      const payload = buildEventPayload(form, true);
+      const response = await fetch("/api/events", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload)
+      });
+      if (!response.ok) {
+        const data = await response.json().catch(() => null);
+        throw new Error(data?.detail ?? "Не удалось создать событие");
+      }
+      const data: ApiSchedule = await response.json();
+      setSchedule(data);
+      setSuccess("Событие успешно добавлено");
+      setForm({ ...defaultEventForm });
+      setProposal(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  const handleComplete = async (eventId: string) => {
+    setError(null);
+    setSuccess(null);
+    try {
+      const response = await fetch(`/api/events/${eventId}/complete`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ completion_time: new Date().toISOString() })
+      });
+      if (!response.ok) {
+        const data = await response.json().catch(() => null);
+        throw new Error(data?.detail ?? "Не удалось завершить событие");
+      }
+      const data: ApiSchedule = await response.json();
+      setSchedule(data);
+      setSuccess("Событие завершено, расписание обновлено");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  const handleSettingsSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    setError(null);
+    setSuccess(null);
+    try {
+      const response = await fetch("/api/settings", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          day_start: toIso(settingsForm.dayStart),
+          day_end: toIso(settingsForm.dayEnd)
+        })
+      });
+      if (!response.ok) {
+        const data = await response.json().catch(() => null);
+        throw new Error(data?.detail ?? "Не удалось обновить настройки");
+      }
+      const data: ApiSchedule = await response.json();
+      setSchedule(data);
+      setSuccess("Настройки рабочего окна сохранены");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  const handleProposal = async () => {
+    setError(null);
+    setSuccess(null);
+    try {
+      const payload = buildEventPayload(form, false);
+      const response = await fetch("/api/proposals", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload)
+      });
+      if (!response.ok) {
+        const data = await response.json().catch(() => null);
+        throw new Error(data?.detail ?? "Не удалось получить рекомендации");
+      }
+      const data: ProposalPreview = await response.json();
+      setProposal(data);
+      setSuccess("Получены рекомендуемые интервалы");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  const activeBlocks = useMemo(() => schedule?.blocks ?? [], [schedule]);
+  const freeWindows = useMemo(() => schedule?.free_windows ?? [], [schedule]);
+
+  return (
+    <div>
+      <h1>Планировщик дня</h1>
+      <p>Управляйте задачами, гибкостью выполнения и смотрите свободные окна в расписании.</p>
+
+      {error ? <p className="error">{error}</p> : null}
+      {success ? <p className="success">{success}</p> : null}
+
+      <div className="flex-row">
+        <section>
+          <h2>Добавить событие</h2>
+          <form onSubmit={handleCreate} data-testid="create-event-form">
+            <label>
+              Идентификатор
+              <input
+                value={form.eventId}
+                onChange={handleFormChange("eventId")}
+                placeholder="meeting-1"
+                required
+              />
+            </label>
+
+            <label>
+              Тип
+              <select value={form.type} onChange={handleFormChange("type")}>
+                <option value="flexible">Гибкое</option>
+                <option value="fixed">Фиксированное</option>
+              </select>
+            </label>
+
+            <label>
+              Длительность (мин)
+              <input
+                type="number"
+                min={5}
+                value={form.durationMinutes}
+                onChange={handleFormChange("durationMinutes")}
+              />
+            </label>
+
+            <label>
+              Важность
+              <input
+                type="number"
+                min={0}
+                step={0.1}
+                value={form.importance}
+                onChange={handleFormChange("importance")}
+              />
+            </label>
+
+            {form.type === "fixed" ? (
+              <label>
+                Начало
+                <input
+                  type="datetime-local"
+                  value={form.start}
+                  onChange={handleFormChange("start")}
+                  required
+                />
+              </label>
+            ) : (
+              <>
+                <label>
+                  Самое раннее начало
+                  <input
+                    type="datetime-local"
+                    value={form.earliestStart}
+                    onChange={handleFormChange("earliestStart")}
+                    required
+                  />
+                </label>
+                <label>
+                  Самое позднее окончание
+                  <input
+                    type="datetime-local"
+                    value={form.latestFinish}
+                    onChange={handleFormChange("latestFinish")}
+                    required
+                  />
+                </label>
+                <label>
+                  Можно дробить
+                  <input
+                    type="checkbox"
+                    checked={form.canSplit}
+                    onChange={handleFormChange("canSplit")}
+                  />
+                </label>
+                <label>
+                  Минимальный кусочек (мин)
+                  <input
+                    type="number"
+                    min={5}
+                    value={form.minChunkMinutes}
+                    onChange={handleFormChange("minChunkMinutes")}
+                  />
+                </label>
+              </>
+            )}
+
+            <div className="flex-row">
+              <button type="submit">Сохранить</button>
+              <button type="button" onClick={handleProposal}>
+                Подобрать окно
+              </button>
+            </div>
+          </form>
+        </section>
+
+        <section>
+          <h2>Настройки рабочего окна</h2>
+          <form onSubmit={handleSettingsSubmit}>
+            <label>
+              Начало дня
+              <input
+                type="datetime-local"
+                value={settingsForm.dayStart}
+                onChange={(event) =>
+                  setSettingsForm((prev) => ({ ...prev, dayStart: event.target.value }))
+                }
+              />
+            </label>
+            <label>
+              Окончание дня
+              <input
+                type="datetime-local"
+                value={settingsForm.dayEnd}
+                onChange={(event) =>
+                  setSettingsForm((prev) => ({ ...prev, dayEnd: event.target.value }))
+                }
+              />
+            </label>
+            <button type="submit">Обновить</button>
+          </form>
+        </section>
+      </div>
+
+      <section>
+        <h2>Расписание</h2>
+        {loading && <p>Загрузка...</p>}
+        {!loading && activeBlocks.length === 0 ? <p>Нет запланированных задач.</p> : null}
+        {activeBlocks.length > 0 && (
+          <table className="table-like" data-testid="schedule-table">
+            <thead>
+              <tr>
+                <th>Событие</th>
+                <th>Начало</th>
+                <th>Окончание</th>
+                <th>Тип</th>
+                <th>Действия</th>
+              </tr>
+            </thead>
+            <tbody>
+              {activeBlocks.map((block) => (
+                <tr key={`${block.event_id}-${block.start}-${block.end}`}>
+                  <td>
+                    <span className="badge">{block.event_id}</span>
+                    {block.chunk_index ? (
+                      <span className="badge">
+                        часть {block.chunk_index}/{block.chunk_count}
+                      </span>
+                    ) : null}
+                  </td>
+                  <td>{formatDateTime(block.start)}</td>
+                  <td>{formatDateTime(block.end)}</td>
+                  <td>{block.type === "fixed" ? "Фикс" : "Гибкое"}</td>
+                  <td>
+                    <button type="button" onClick={() => handleComplete(block.event_id)}>
+                      Завершить
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+
+      <section>
+        <h2>Свободные окна</h2>
+        {freeWindows.length === 0 ? <p>Свободных окон нет.</p> : null}
+        <ul>
+          {freeWindows.map((window) => (
+            <li key={`${window.start}-${window.end}`}>
+              {formatDateTime(window.start)} — {formatDateTime(window.end)}
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      {proposal ? (
+        <section>
+          <h2>Рекомендации для текущей формы</h2>
+          {proposal.blocks.length === 0 ? (
+            <p>Нет подходящих интервалов.</p>
+          ) : (
+            <table className="table-like" data-testid="proposal-table">
+              <thead>
+                <tr>
+                  <th>Начало</th>
+                  <th>Окончание</th>
+                  <th>Тип</th>
+                </tr>
+              </thead>
+              <tbody>
+                {proposal.blocks.map((block) => (
+                  <tr key={`${block.event_id}-${block.start}`}>
+                    <td>{formatDateTime(block.start)}</td>
+                    <td>{formatDateTime(block.end)}</td>
+                    <td>{block.type === "fixed" ? "Фикс" : "Гибкое"}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </section>
+      ) : null}
+    </div>
+  );
+};
+
+export default App;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import "./styles.css";
+
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,103 @@
+:root {
+  font-family: "Inter", system-ui, sans-serif;
+  background: #f6f6f6;
+  color: #1a1a1a;
+}
+
+body {
+  margin: 0;
+}
+
+#root {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+h1 {
+  margin-bottom: 1.5rem;
+}
+
+form {
+  display: grid;
+  gap: 0.75rem;
+}
+
+fieldset {
+  border: 1px solid #ddd;
+  padding: 1rem;
+  border-radius: 8px;
+  background: #fff;
+}
+
+label {
+  font-weight: 500;
+}
+
+input,
+select,
+button {
+  padding: 0.5rem;
+  border-radius: 6px;
+  border: 1px solid #bbb;
+  font-size: 1rem;
+}
+
+button {
+  background: #2563eb;
+  color: #fff;
+  cursor: pointer;
+  border: none;
+}
+
+button:hover {
+  background: #1d4ed8;
+}
+
+section {
+  margin-bottom: 2rem;
+}
+
+.table-like {
+  width: 100%;
+  border-collapse: collapse;
+  background: #fff;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.table-like th,
+.table-like td {
+  padding: 0.75rem;
+  border-bottom: 1px solid #eee;
+  text-align: left;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  background: #eff6ff;
+  color: #1d4ed8;
+  padding: 0.25rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+}
+
+.flex-row {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.flex-row > * {
+  flex: 1 1 320px;
+}
+
+.error {
+  color: #b91c1c;
+}
+
+.success {
+  color: #15803d;
+}

--- a/frontend/tests/e2e.spec.ts
+++ b/frontend/tests/e2e.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Планировщик дня", () => {
+  test("создание гибкого события отображает его в расписании", async ({ page }) => {
+    const dayStart = "2024-01-01T06:00:00.000Z";
+    const dayEnd = "2024-01-01T18:00:00.000Z";
+
+    const initialSchedule = {
+      day_start: dayStart,
+      day_end: dayEnd,
+      events: [],
+      blocks: [],
+      free_windows: [{ start: dayStart, end: dayEnd }]
+    };
+
+    const updatedSchedule = {
+      day_start: dayStart,
+      day_end: dayEnd,
+      events: [
+        {
+          event_id: "deep-work",
+          type: "flexible",
+          duration_minutes: 120,
+          importance: 1,
+          details: {
+            earliest_start: "2024-01-01T07:00:00.000Z",
+            latest_finish: "2024-01-01T12:00:00.000Z",
+            can_split: false,
+            min_chunk: "0:30:00"
+          }
+        }
+      ],
+      blocks: [
+        {
+          start: "2024-01-01T07:00:00.000Z",
+          end: "2024-01-01T09:00:00.000Z",
+          event_id: "deep-work",
+          type: "flexible",
+          chunk_index: null,
+          chunk_count: null
+        }
+      ],
+      free_windows: [
+        { start: "2024-01-01T06:00:00.000Z", end: "2024-01-01T07:00:00.000Z" },
+        { start: "2024-01-01T09:00:00.000Z", end: "2024-01-01T18:00:00.000Z" }
+      ]
+    };
+
+    let scheduleCalls = 0;
+
+    await page.route("**/api/schedule", async (route) => {
+      scheduleCalls += 1;
+      if (scheduleCalls === 1) {
+        await route.fulfill({ json: initialSchedule });
+      } else {
+        await route.fulfill({ json: updatedSchedule });
+      }
+    });
+
+    await page.route("**/api/events", async (route) => {
+      expect(route.request().method()).toBe("POST");
+      await route.fulfill({ status: 201, json: updatedSchedule });
+    });
+
+    await page.goto("/");
+
+    await expect(page.getByText("Свободные окна")).toBeVisible();
+    await expect(page.getByRole("list")).toContainText("06.01.2024");
+
+    await page.getByLabel("Идентификатор").fill("deep-work");
+    await page.getByLabel("Длительность (мин)").fill("120");
+    await page.getByLabel("Самое раннее начало").fill("2024-01-01T09:00");
+    await page.getByLabel("Самое позднее окончание").fill("2024-01-01T12:00");
+
+    await page.getByRole("button", { name: "Сохранить" }).click();
+
+    await expect(page.getByTestId("schedule-table")).toContainText("deep-work");
+    await expect(page.getByText("Событие успешно добавлено")).toBeVisible();
+    await expect(page.getByTestId("schedule-table")).toContainText("Гибкое");
+  });
+});

--- a/frontend/tests/playwright.config.ts
+++ b/frontend/tests/playwright.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./",
+  timeout: 60000,
+  expect: { timeout: 5000 },
+  use: {
+    baseURL: process.env.E2E_BASE_URL || "http://localhost:5173",
+    trace: "on-first-retry"
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] }
+    }
+  ]
+});

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": "./src",
+    "types": ["vite/client", "@types/node"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    proxy: {
+      "/api": {
+        target: "http://localhost:8000",
+        changeOrigin: true,
+        secure: false
+      }
+    }
+  }
+});

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi>=0.95,<0.110
+uvicorn[standard]>=0.25
+pydantic>=1.10,<2.0

--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -1,0 +1,5 @@
+"""FastAPI application exposing the scheduling engine."""
+
+from .main import create_app
+
+__all__ = ["create_app"]

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -1,0 +1,318 @@
+"""REST API for interacting with the scheduling engine."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from typing import Dict, List, Literal, Optional
+
+from fastapi import FastAPI, HTTPException, status
+from pydantic import BaseModel, Field, root_validator
+
+from ..scheduler.models import Event, FixedEvent, FlexibleEvent
+from ..scheduler.optimizer import (
+    ScheduledBlock,
+    schedule_events,
+    update_schedule_after_completion,
+)
+
+
+def _default_day_bounds(reference: Optional[datetime] = None) -> tuple[datetime, datetime]:
+    reference = reference or datetime.utcnow()
+    start = reference.replace(hour=8, minute=0, second=0, microsecond=0)
+    end = reference.replace(hour=20, minute=0, second=0, microsecond=0)
+    if end <= start:
+        end = start + timedelta(hours=12)
+    return start, end
+
+
+@dataclass
+class _SchedulerState:
+    """Container for persisted scheduler state."""
+
+    day_start: datetime
+    day_end: datetime
+    events: Dict[str, Event] = field(default_factory=dict)
+    blocks: List[ScheduledBlock] = field(default_factory=list)
+
+    def reschedule(self) -> None:
+        """Re-run the optimizer for all known events."""
+
+        try:
+            self.blocks = schedule_events(
+                existing_blocks=(),
+                candidates=self.events.values(),
+                day_start=self.day_start,
+                day_end=self.day_end,
+            )
+        except ValueError as exc:  # pragma: no cover - validation bubble up
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+
+    def upsert_event(self, event_id: str, event: Event) -> None:
+        self.events[event_id] = event
+        self.reschedule()
+
+    def delete_event(self, event_id: str) -> None:
+        if event_id in self.events:
+            del self.events[event_id]
+            self.reschedule()
+
+    def complete_event(self, event_id: str, completion_time: datetime) -> None:
+        if event_id not in self.events:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Event '{event_id}' was not found.",
+            )
+        self.blocks = update_schedule_after_completion(
+            schedule=self.blocks,
+            event_id=event_id,
+            completion_time=completion_time,
+            day_start=self.day_start,
+            day_end=self.day_end,
+        )
+        del self.events[event_id]
+
+    def free_windows(self) -> List[dict[str, datetime]]:
+        cursor = self.day_start
+        windows: List[dict[str, datetime]] = []
+        for block in sorted(self.blocks, key=lambda blk: blk.start):
+            if block.start > cursor:
+                windows.append({"start": cursor, "end": block.start})
+            cursor = max(cursor, block.end)
+        if cursor < self.day_end:
+            windows.append({"start": cursor, "end": self.day_end})
+        return windows
+
+
+class EventPayload(BaseModel):
+    """Shared payload for fixed and flexible events."""
+
+    type: Literal["fixed", "flexible"]
+    duration_minutes: int = Field(gt=0)
+    importance: float = Field(default=1.0, ge=0.0)
+    start: Optional[datetime] = Field(default=None, description="Start time for fixed events")
+    earliest_start: Optional[datetime] = Field(
+        default=None, description="Earliest allowed start for flexible events"
+    )
+    latest_finish: Optional[datetime] = Field(
+        default=None, description="Latest allowed finish for flexible events"
+    )
+    can_split: bool = Field(default=False)
+    min_chunk_minutes: int = Field(default=30, gt=0)
+
+    @root_validator
+    def _validate_event(cls, values: dict[str, object]) -> dict[str, object]:
+        event_type = values.get("type")
+        if event_type == "fixed":
+            if values.get("start") is None:
+                raise ValueError("Fixed events require a 'start' timestamp")
+        elif event_type == "flexible":
+            if values.get("earliest_start") is None or values.get("latest_finish") is None:
+                raise ValueError("Flexible events require 'earliest_start' and 'latest_finish'")
+        return values
+
+    def build_event(self, event_id: str) -> Event:
+        duration = timedelta(minutes=self.duration_minutes)
+        if self.type == "fixed":
+            assert self.start is not None  # for type checkers
+            return FixedEvent(
+                event_id=event_id,
+                start=self.start,
+                duration=duration,
+                importance=self.importance,
+            )
+        assert self.earliest_start is not None
+        assert self.latest_finish is not None
+        return FlexibleEvent(
+            event_id=event_id,
+            duration=duration,
+            importance=self.importance,
+            earliest_start=self.earliest_start,
+            latest_finish=self.latest_finish,
+            can_split=self.can_split,
+            min_chunk=timedelta(minutes=self.min_chunk_minutes),
+        )
+
+
+class EventCreateRequest(EventPayload):
+    event_id: str = Field(min_length=1)
+
+
+class EventUpdateRequest(EventPayload):
+    ...
+
+
+class EventResponse(BaseModel):
+    event_id: str
+    type: Literal["fixed", "flexible"]
+    duration_minutes: float
+    importance: float
+    details: dict[str, object]
+
+
+class BlockResponse(BaseModel):
+    start: datetime
+    end: datetime
+    event_id: str
+    type: Literal["fixed", "flexible"]
+    chunk_index: Optional[int]
+    chunk_count: Optional[int]
+
+
+class ScheduleResponse(BaseModel):
+    day_start: datetime
+    day_end: datetime
+    events: List[EventResponse]
+    blocks: List[BlockResponse]
+    free_windows: List[dict[str, datetime]]
+
+
+class CompletionRequest(BaseModel):
+    completion_time: datetime
+
+
+class SettingsUpdate(BaseModel):
+    day_start: datetime
+    day_end: datetime
+
+    @root_validator
+    def _check_bounds(cls, values: dict[str, object]) -> dict[str, object]:
+        start = values.get("day_start")
+        end = values.get("day_end")
+        if isinstance(start, datetime) and isinstance(end, datetime) and end <= start:
+            raise ValueError("day_end must be after day_start")
+        return values
+
+
+class ProposalRequest(EventPayload):
+    event_id: Optional[str] = None
+
+
+class ProposalResponse(BaseModel):
+    blocks: List[BlockResponse]
+    free_windows: List[dict[str, datetime]]
+
+
+def _serialize_event(event: Event) -> EventResponse:
+    if isinstance(event, FixedEvent):
+        details = {"start": event.start}
+        event_type: Literal["fixed", "flexible"] = "fixed"
+    elif isinstance(event, FlexibleEvent):
+        details = {
+            "earliest_start": event.earliest_start,
+            "latest_finish": event.latest_finish,
+            "can_split": event.can_split,
+            "min_chunk": event.min_chunk,
+        }
+        event_type = "flexible"
+    else:  # pragma: no cover - future proofing
+        raise TypeError(f"Unsupported event type: {type(event)!r}")
+    return EventResponse(
+        event_id=event.event_id,
+        type=event_type,
+        duration_minutes=event.duration.total_seconds() / 60,
+        importance=event.importance,
+        details=details,
+    )
+
+
+def _serialize_block(block: ScheduledBlock) -> BlockResponse:
+    event = block.event
+    event_type: Literal["fixed", "flexible"] = "fixed" if isinstance(event, FixedEvent) else "flexible"
+    return BlockResponse(
+        start=block.start,
+        end=block.end,
+        event_id=event.event_id,
+        type=event_type,
+        chunk_index=block.chunk_index,
+        chunk_count=block.chunk_count,
+    )
+
+
+def create_app() -> FastAPI:
+    day_start, day_end = _default_day_bounds()
+    state = _SchedulerState(day_start=day_start, day_end=day_end)
+
+    app = FastAPI(title="Calendar Scheduler API")
+
+    @app.get("/api/schedule", response_model=ScheduleResponse)
+    def get_schedule() -> ScheduleResponse:
+        events = [_serialize_event(event) for event in state.events.values()]
+        blocks = [_serialize_block(block) for block in state.blocks]
+        return ScheduleResponse(
+            day_start=state.day_start,
+            day_end=state.day_end,
+            events=events,
+            blocks=blocks,
+            free_windows=state.free_windows(),
+        )
+
+    @app.post("/api/events", status_code=status.HTTP_201_CREATED, response_model=ScheduleResponse)
+    def create_event(payload: EventCreateRequest) -> ScheduleResponse:
+        if payload.event_id in state.events:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Event '{payload.event_id}' already exists.",
+            )
+        event = payload.build_event(payload.event_id)
+        state.upsert_event(payload.event_id, event)
+        return get_schedule()
+
+    @app.put("/api/events/{event_id}", response_model=ScheduleResponse)
+    def update_event(event_id: str, payload: EventUpdateRequest) -> ScheduleResponse:
+        if event_id not in state.events:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Event '{event_id}' was not found.",
+            )
+        event = payload.build_event(event_id)
+        state.upsert_event(event_id, event)
+        return get_schedule()
+
+    @app.delete("/api/events/{event_id}", response_model=ScheduleResponse)
+    def delete_event(event_id: str) -> ScheduleResponse:
+        if event_id not in state.events:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Event '{event_id}' was not found.",
+            )
+        state.delete_event(event_id)
+        return get_schedule()
+
+    @app.post("/api/events/{event_id}/complete", response_model=ScheduleResponse)
+    def complete_event(event_id: str, payload: CompletionRequest) -> ScheduleResponse:
+        state.complete_event(event_id, payload.completion_time)
+        return get_schedule()
+
+    @app.put("/api/settings", response_model=ScheduleResponse)
+    def update_settings(payload: SettingsUpdate) -> ScheduleResponse:
+        state.day_start = payload.day_start
+        state.day_end = payload.day_end
+        state.reschedule()
+        return get_schedule()
+
+    @app.post("/api/proposals", response_model=ProposalResponse)
+    def propose_slot(payload: ProposalRequest) -> ProposalResponse:
+        event_id = payload.event_id or "__proposal__"
+        event = payload.build_event(event_id)
+        try:
+            preview_schedule = schedule_events(
+                existing_blocks=state.blocks,
+                candidates=[event],
+                day_start=state.day_start,
+                day_end=state.day_end,
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+        preview_blocks = [
+            block for block in preview_schedule if block.event.event_id == event.event_id
+        ]
+        return ProposalResponse(
+            blocks=[_serialize_block(block) for block in preview_blocks],
+            free_windows=state.free_windows(),
+        )
+
+    return app
+
+
+app = create_app()


### PR DESCRIPTION
## Summary
- implement a FastAPI service under `src/api` to manage events, free windows, and scheduling actions
- scaffold a Vite + React frontend with calendar views, task forms, and proposal visualisation
- document setup steps for backend/frontend and add Playwright E2E coverage for the main flow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e42c410fd4832e8d854d2fa0fe28d7